### PR TITLE
New BaseUrl setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,18 @@ You can modify the variables inside `data/settings.json`
 - `streamThrottleMS` = add throttle to the encryption, decryption, upload & download buffer to limit cpu usage
 - `pbkdf2Iterations` = key derivation algorithm iteration, the higher the better, but 100000 should be enough
 - `cmdUploadDefaultDurationMinute` = default file duration if you upload file through curl if duration is not specified
+- `BaseUrl` = a prefix for all the endpoints, which is useful when hosting multiple services on the same hostname
 
 You can modify CPU/memory usage by calculating the memory usage / sec with `streamSizeLimitKB * (1000/streamThrottleMS)`, the default setting can handle 40 MB of data on file upload, download, encryption & decryption / second, you can tune this down if needed
+
+If you want to run GigaPaste behind a caddy reverse proxy, you can, for example, set the `BaseUrl` setting to "/gigapaste" and use the following config in the CaddyFile:
+```
+yoursite.com {
+    encode zstd gzip
+    reverse_proxy /gigapaste/* gigapaste:80
+}
+```
+and access GigaPaste at `yoursite.com/gigapaste/`
 
 # Curl upload ⬆️
 `curl -F "file=@main.go" -F "duration=10" -F "pass=123" -F "burn=true" yoursite.com`  

--- a/data/settings.json
+++ b/data/settings.json
@@ -6,5 +6,7 @@
 
 	"pbkdf2Iterations": 10000,
 	
-	"cmdUploadDefaultDurationMinute" : 10
+	"cmdUploadDefaultDurationMinute" : 10,
+
+	"BaseUrl": "/gigapaste"
 }

--- a/data/settings.json
+++ b/data/settings.json
@@ -8,5 +8,5 @@
 	
 	"cmdUploadDefaultDurationMinute" : 10,
 
-	"BaseUrl": "/gigapaste"
+	"BaseUrl": ""
 }

--- a/handlers.go
+++ b/handlers.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -133,7 +134,7 @@ func FileHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 				return
 			}
 
-			_, err = io.WriteString(w, r.Host+"/"+randUrl)
+			_, err = io.WriteString(w, r.Host+Global.BaseUrl+"/"+randUrl)
 			if err != nil {
 				fmt.Println(err)
 				return
@@ -154,7 +155,7 @@ func FileHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 				return
 			}
 
-			_, err = io.WriteString(w, r.Host+"/"+randUrl)
+			_, err = io.WriteString(w, r.Host+Global.BaseUrl+"/"+randUrl)
 			if err != nil {
 				fmt.Println(err)
 				return
@@ -253,7 +254,7 @@ func TextHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 
 	}
 
-	_, err = io.WriteString(w, r.Host+"/"+randUrl)
+	_, err = io.WriteString(w, r.Host+Global.BaseUrl+"/"+randUrl)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -263,7 +264,8 @@ func TextHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 
 func DownloadHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 
-	path := r.URL.Path[1:] //dont include the '/'
+	pathParts := strings.Split(r.URL.Path, "/")
+	path := pathParts[len(pathParts)-1]
 
 	var fType string
 	var fFileName string
@@ -306,7 +308,7 @@ func DownloadHandler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 			return
 		}
 
-		err = tmpl.Execute(w, struct{ Path string }{Path: path})
+		err = tmpl.Execute(w, struct{ Path string }{Path: Global.BaseUrl[1:] + "/" + path})
 
 		if err != nil {
 			fmt.Println(err)

--- a/main.go
+++ b/main.go
@@ -34,10 +34,10 @@ var settingsFile string
 // Theoretically won't ever conflict with generated URL, because generated URL won't contain a dot "."
 func serveFile(w http.ResponseWriter, r *http.Request, next func(w2 http.ResponseWriter, r2 *http.Request)) {
 	// Remove leading slash from the URL path
-	path := strings.TrimPrefix(r.URL.Path, "/")
-
+	path := strings.TrimPrefix(r.URL.Path, Global.BaseUrl+"/")
+	fmt.Printf("path: %s\n", path)
 	if path == "" {
-		http.Redirect(w, r, "/index.html", http.StatusFound)
+		http.Redirect(w, r, Global.BaseUrl+"/index.html", http.StatusFound)
 		return
 	}
 
@@ -89,7 +89,9 @@ func main() {
 	db := InitDatabase()
 	InitSettings()
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(Global.BaseUrl+"/", func(w http.ResponseWriter, r *http.Request) {
+
+		fmt.Printf("handling: %s %s\n", r.Method, r.URL.Path)
 
 		if r.Method == http.MethodGet {
 
@@ -119,7 +121,7 @@ func main() {
 
 	})
 
-	http.HandleFunc("/postText", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(Global.BaseUrl+"/postText", func(w http.ResponseWriter, r *http.Request) {
 
 		r.Body = http.MaxBytesReader(w, r.Body, 1024*1024*Global.TextSizeLimit)
 		TextHandler(w, r, db)

--- a/settings.go
+++ b/settings.go
@@ -17,13 +17,13 @@ import (
 )
 
 type Setting struct {
-	FileSizeLimit                  int64 `json:"FileSizeLimitMB"`                //maximum allowed upload file size
-	TextSizeLimit                  int64 `json:"TextSizeLimitMB"`                //maximum allowed upload text size
-	StreamSizeLimit                int64 `json:"StreamSizeLimitKB"`              //streaming buffer size
-	StreamThrottle                 int64 `json:"StreamThrottleMS"`               //streaming Sleep() timer to not use too much cpu
-	Pbkdf2Iteraions                int   `json:"Pbkdf2Iteraions"`                //key derviation function iterations
-	CmdUploadDefaultDurationMinute int64 `json:"CmdUploadDefaultDurationMinute"` //default file duration when uploaded through curl / other cmdline
-
+	FileSizeLimit                  int64  `json:"FileSizeLimitMB"`                //maximum allowed upload file size
+	TextSizeLimit                  int64  `json:"TextSizeLimitMB"`                //maximum allowed upload text size
+	StreamSizeLimit                int64  `json:"StreamSizeLimitKB"`              //streaming buffer size
+	StreamThrottle                 int64  `json:"StreamThrottleMS"`               //streaming Sleep() timer to not use too much cpu
+	Pbkdf2Iteraions                int    `json:"Pbkdf2Iteraions"`                //key derviation function iterations
+	CmdUploadDefaultDurationMinute int64  `json:"CmdUploadDefaultDurationMinute"` //default file duration when uploaded through curl / other cmdline
+	BaseUrl                        string `json:"BaseUrl"`                        //url prefix for reverse proxy setups (must include leading /)
 }
 
 var Global Setting
@@ -43,5 +43,7 @@ func InitSettings() {
 		fmt.Println("Error decoding JSON:", err)
 		return
 	}
+
+	fmt.Printf("Settings loaded: %+v\n", Global)
 
 }

--- a/static/script.js
+++ b/static/script.js
@@ -218,6 +218,7 @@ function upload() {
 
 		let minutes = duration.value * convertMinutes[durationModifiers.value]
 
+		let baseURL = window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"))
 		if(files){
 		
 			const formData = new FormData();
@@ -230,14 +231,14 @@ function upload() {
 				formData.append('file', files[i]); //'file' as the key
 			}
 
-			xhr.open('POST', '/'); 
+			xhr.open('POST', baseURL + "/");
 			xhr.send(formData);
 
 		}else{
 
 			if(textArea.value.trim () !== ""){
 
-				xhr.open('POST', '/postText');
+				xhr.open('POST', baseURL + '/postText');
 				xhr.send(JSON.stringify({duration: minutes, pass: password.value, burn: burn.checked, text: textArea.value}));
 
 			}


### PR DESCRIPTION
I wanted to run GigaPaste behind a Caddy reverse proxy, along side other services in the same host.

I want to be able to access GigaPaste in a URL like `yourhost.com/gigapaste` but also access another service using `yourhost.com/otherservice`

To do this I added a new setting that prefixes all routes.